### PR TITLE
Add optional sorting field

### DIFF
--- a/classes/adm_RoleMembers.php
+++ b/classes/adm_RoleMembers.php
@@ -54,6 +54,7 @@ class RoleMembers
     public  $db;                        ///< Database object to handle the communication with the database. This must be public because of session handling.
     private $limit;                     ///< Limit of the query result
     private $memberCondition;           ///< Internal member condition
+    private $memberOrderBy;             ///< Ordering sequence for retrieval of role members
     private $roleId;                    ///< Requested role ID
     private $showMembers;               ///< Paramter to handle member status of the query ( default "0" for active members of the role )
     private $sqlConditions;             ///< Internal SQL condition statement for the query
@@ -75,6 +76,7 @@ class RoleMembers
     public function __construct(&$db, $rol_id = 0, $showMembers = 0)
     {
         global $gCurrentOrganization;
+        global $plg_wc_printingSequenceFieldName;
 
         $this->additionalProfileFields  = '';
         $this->additionalSQLJoin        = '';
@@ -110,6 +112,12 @@ class RoleMembers
                                         AND rol_cat_id = cat_id
                                         AND (  cat_org_id = '. $gCurrentOrganization->getValue('org_id'). '
                                             OR cat_org_id IS NULL )) ';
+
+        if ($plg_wc_printingSequenceFieldName) {
+            $this->memberOrderBy = 'CAST ('.$plg_wc_printingSequenceFieldName.' AS INT)';
+        } else {
+            $this->memberOrderBy = 'last_name, first_name';
+        }
     }
 
     /**
@@ -188,7 +196,7 @@ class RoleMembers
                   ON mem.mem_rol_id  = rol.rol_id '. $this->sqlConditions .'
                  AND mem.mem_usr_id  = usr_id
                 WHERE '. $this->memberCondition. '
-                ORDER BY last_name, first_name '.$this->limit;
+                ORDER BY '.$this->memberOrderBy.' '.$this->limit;
 
         $resultUser = $this->db->query($sql);
         while($row = $resultUser->fetch())

--- a/config_sample.php
+++ b/config_sample.php
@@ -43,4 +43,10 @@ $plg_wc_arrCustomProfileFields = array('UserEmail' => 'EMAIL');
 $plg_wc_arrCustomText = array(  'Text_de' => 'Dieser Textknoten wurde in der config.php des Plugin im Array $plg_wc_arrCustomProfileFields" erstellt und ersetzt den Platzhalter "${Text_de}" im Template.',
                                 'Text_en' => 'This text is defined in the config.php of the plugin. It replaces the placeholder "${Text_en}" defined in the array "$plg_wc_arrCustomProfileFields".');
 
+//
+// If this variable is defined, the serial letter will be sorted according to a numerical field in the profile data of the role members. Otherwise, sorting is done by name and first name.
+// A sortable profile field with this name must exist.
+//
+// $plg_wc_printingSequenceFieldName = 'Druckreihenfolge';
+
 ?>

--- a/written_communications_functions.php
+++ b/written_communications_functions.php
@@ -116,6 +116,10 @@ try {
     if (!isset($plg_wc_arrCustomText)) {
         $plg_wc_arrCustomText = array();
     }
+    if (!isset($plg_wc_printingSequenceFieldName))
+    {
+        $plg_wc_printingSequenceFieldName = null;
+    }
     // Access for users only!
     if ($gCurrentUser->getValue('usr_id') == 0) {
         throw new Exception('SYS_NO_RIGHTS');
@@ -166,6 +170,11 @@ try {
         // add additional profile fields to the role object if defined
         if (count($plg_wc_arrCustomProfileFields) > 0) {
             $members->addProfileFields($plg_wc_arrCustomProfileFields);
+        }
+        // add profile field for sorting order if it is defined
+        if ($plg_wc_printingSequenceFieldName) {
+            $members->addProfileFields(array('PrintSequence' => strtoupper($plg_wc_printingSequenceFieldName)));
+            error_log('Adding sort field');
         }
 
         $arrMembers = $members->getRoleMembers();


### PR DESCRIPTION
This PR adds an optional field configuration to activate sorted printing. The filed contains a numerical printing sequence, e.g. integers, and can be maintained through the admidio profile. All mail merge outputs will be sorted in ascending order according to this field.

closes #28 